### PR TITLE
Implement a basic configuration file

### DIFF
--- a/simple-wd/ap-scanner/cmd.go
+++ b/simple-wd/ap-scanner/cmd.go
@@ -11,10 +11,7 @@ import (
 	"strings"
 )
 
-const (
-	interfaceName string = "wlan0" // Should eventually move to a configuration file
-	iwCommandName string = "iw"
-)
+const iwCommandName string = "iw"
 
 type IWCommand struct {
 	interfaceName string
@@ -72,7 +69,7 @@ func isValidInterfaceName(name string) (bool, error) {
 
 // NewIWCommand does a few checks to ensure the command can run successfully before
 // creating the command
-func NewIWCommand() (*IWCommand, error) {
+func NewIWCommand(interfaceName string) (*IWCommand, error) {
 	if !isCommandAvailable(iwCommandName) {
 		return nil, &CommandNotFoundError{iwCommandName}
 	}

--- a/simple-wd/ap-scanner/cmd_test.go
+++ b/simple-wd/ap-scanner/cmd_test.go
@@ -34,7 +34,7 @@ BSS mac3(on testwlan0)
 
 	output = strings.TrimSpace(output)
 
-	iw := &IWCommand{}
+	iw := &IWCommand{"testInterface"}
 	accessPoints := iw.parseScan(output)
 
 	require.Len(t, accessPoints, 2)

--- a/simple-wd/config.go
+++ b/simple-wd/config.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const configFile = "config.yaml" // Default config file name
+
+type Configuration struct {
+	InterfaceName       string `yaml:"interfaceName"`
+	ScanIntervalSeconds uint64 `yaml:"scanInterval"`
+}
+
+func defaultConfig() *Configuration {
+	return &Configuration{
+		InterfaceName:       "wlan0",
+		ScanIntervalSeconds: 60,
+	}
+}
+
+func NewConfig() *Configuration {
+	newConfig := defaultConfig()
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Failed to read config file '%s': %s\nUsing default configuration values\n",
+			configFile,
+			err,
+		)
+		return newConfig
+	}
+
+	// yaml.Unmarshal applies the YAML config to the config object
+	if err = yaml.Unmarshal(data, &newConfig); err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"Failed to parse YAML in config file '%s': %s\nUsing default configuration values\n",
+			configFile,
+			err,
+		)
+	}
+
+	return newConfig
+}

--- a/simple-wd/config.yaml
+++ b/simple-wd/config.yaml
@@ -1,0 +1,4 @@
+# The name of the wireless interface to use to scan for access points. Default: wlan0
+interfaceName:
+# Interval, in seconds, of how often to scan for access points. Default: 60
+scanInterval:

--- a/simple-wd/config_test.go
+++ b/simple-wd/config_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	defaultConfig := defaultConfig()
+	assert.IsType(t, &Configuration{}, defaultConfig)
+}

--- a/simple-wd/simple-wd.go
+++ b/simple-wd/simple-wd.go
@@ -23,7 +23,8 @@ func main() {
 
 	// Rescanning over interval
 	interval := time.Second * time.Duration(config.ScanIntervalSeconds)
-	for range time.Tick(interval) {
+	ticker := time.NewTicker(interval)
+	for ; true; <-ticker.C {
 		accessPoints := iw.GetAccessPoints()
 
 		// Sanity check: print data

--- a/simple-wd/simple-wd.go
+++ b/simple-wd/simple-wd.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"time"
+
 	scanner "simple-wd/ap-scanner"
 )
 
@@ -14,18 +15,17 @@ func main() {
 		log.Fatal("The wardriver program needs to be run as root")
 	}
 
-	iw, err := scanner.NewIWCommand()
+	config := NewConfig()
+	iw, err := scanner.NewIWCommand(config.InterfaceName)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-
 	// Rescanning over interval
-	INTERVAL := 30 * time.Second;
-	for range time.Tick(INTERVAL) {
-    	
+	interval := time.Second * time.Duration(config.ScanIntervalSeconds)
+	for range time.Tick(interval) {
 		accessPoints := iw.GetAccessPoints()
-	
+
 		// Sanity check: print data
 		for _, accessPoint := range accessPoints {
 			fmt.Printf(


### PR DESCRIPTION
The config file is stored in `config.yaml` in the simple-wd directory. If no file is found or there is an error while reading/parsing the file, the default config will be used.

The second commit also implements a small improvement to scan right when the program starts and then sleeps instead of sleeping and then scanning.