### PR TITLE
Add GitHub workflows to test code after pushes and PRs

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,28 @@
+name: Check for typos
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "**.md"
+      - "**.yml"
+      - "**.yaml"
+      - "Makefile"
+  pull_request:
+    paths:
+      - "**.go"
+      - "**.md"
+      - "**.yml"
+      - "**.yaml"
+      - "Makefile"
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/test_wardrivers.yml
+++ b/.github/workflows/test_wardrivers.yml
@@ -1,0 +1,48 @@
+name: Build, test, lint, and format each wardriver
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "*/go.mod"
+      - "*/go.sum"
+      - "*/Makefile"
+      - ".github/workflows/build-test.yml"
+  pull_request:
+    paths:
+      - "**.go"
+      - "*/go.mod"
+      - "*/go.sum"
+      - "*/Makefile"
+      - ".github/workflows/build-test.yml"
+
+jobs:
+  ci-test:
+    # TODO: Add support for more platforms once each wardriver supports Windows and MacOS
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        wardriver-path: [ 'simple-wd' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - name: Build wardriver
+        run: make build --directory=${{ matrix.wardriver-path }}
+      - name: Test wardriver
+        run: make test --directory=${{ matrix.wardriver-path }}
+      - name: Lint wardriver
+        uses: golangci/golangci-lint-action@v3
+        with:
+          working-directory: ${{ matrix.wardriver-path }}
+      - name: Format wardriver
+        run: |
+          # Exit with an error if gofmt reports any files to fix
+          if [ "$(gofmt -s -l ${{ matrix.wardriver-path }} | wc -l)" -gt 0 ]; then
+            exit 1
+          fi

--- a/.github/workflows/test_wardrivers.yml
+++ b/.github/workflows/test_wardrivers.yml
@@ -9,14 +9,14 @@ on:
       - "*/go.mod"
       - "*/go.sum"
       - "*/Makefile"
-      - ".github/workflows/build-test.yml"
+      - ".github/workflows/test_wardrivers.yml"
   pull_request:
     paths:
       - "**.go"
       - "*/go.mod"
       - "*/go.sum"
       - "*/Makefile"
-      - ".github/workflows/build-test.yml"
+      - ".github/workflows/test_wardrivers.yml"
 
 jobs:
   ci-test:


### PR DESCRIPTION
Four different CI tests will be run on every PR and push to the main branch: build, test, lint, and format. Additionally, codespell is run to check any comments or documentation for typos.

The lint action will only run golangci-lint, not every linter in `make lint`. Additionally, the format step will only check if files need to be formatted, but `go mod tidy` will not be run.

The steps could be split into different jobs for a faster runtime, but each step needs to be run inside the wardriver path, so I decided to group them together. Also, the little more amount of time it takes to run doesn't matter much (we can't take advantage of GitHub running jobs in parallel) as it is a small project right now.